### PR TITLE
Value cannot contain a colon character

### DIFF
--- a/frontmatter.php
+++ b/frontmatter.php
@@ -95,7 +95,7 @@ class FrontMatter
         foreach($front_matter as $variable)
         {
             # Explode so we can see both key and value
-            $var = explode(": ",$variable);
+            $var = explode(": ",$variable,2);
             
             # Ignore empty lines
             if (count($var) > 1) {


### PR DESCRIPTION
If you would create file with the FrontMatter block, you could not use a colon character in values. You can get rid of the problem just by adding a limit to `explode` function.
