### PR TITLE
Use yaml_parse from PECL instead of manual parse to fix multiline issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ An easy to use class for handling YAML frontmatter in PHP.
 
 ### What does this class do?
 
-YAML Front Matter is a technique used to keep metadata about the file seperated from the actual content inside the file, while still only having 1 file. This simple PHP class allows you to **read such files**, and return each of the **metadata** or **content** independantly.
+YAML Front Matter is a technique used to keep metadata about the file seperated from the actual content inside the file, while still only having one file. This simple PHP class allows you to **read such files**, and return each of the **metadata** or **content** independantly.
 
 ### What files are compatible with this class?
 
-This class is currently a stict format. The current format is following the original [Jekyll](https://github.com/mojombo/jekyll/wiki/yaml-front-matter) project example. As far as we know the current file format is only compatible with [Statamic](http://statamic.com/ "Statamic is a flexible, flat file CMS").
+Any Jekyll file with Front Matter can be parsed my this class.
 
 
 ### The format:
 
-The current strict format is as follows:
+The basic format is as follows:
 
 	---
 	foo: bar
@@ -31,6 +31,7 @@ The current strict format is as follows:
 
 There is no conversion from Markdown so you will have to implement your own, or if you want you can simply use HTML and even PHP directly.
 
-### How to use this class?
+### Installation / How to use
 
-example/example.php is an example file that shows you how to use this class.
+1. Make sure you have the **yaml** PECL extension for PHP installed.
+2. Include the "frontmatter.php" file in your PHP, then check out example/example.php for an example of how to use.

--- a/frontmatter.php
+++ b/frontmatter.php
@@ -104,24 +104,8 @@ class FrontMatter
                 $content = $document[2];
         }
 
-        # Split lines in front matter to get variables
-        $front_matter = explode("\n",$front_matter);
-        foreach($front_matter as $variable)
-        {
-            # Explode so we can see both key and value
-            $var = explode(": ",$variable,2);
-
-            # Ignore empty lines
-            if (count($var) > 1) {
-
-                # Store Key and Value
-                $key = $var[0];
-                $val = $var[1];
-
-                # Store Content in Final array
-                $final[$key] = $val;
-            }
-        }
+        # Parse YAML
+        $final = yaml_parse($front_matter);
 
         # Store Content in Final array
         $final['content'] = $content;


### PR DESCRIPTION
This change makes the parse much more robust by using the yaml PECL extension to parse the yaml, and thus now supports all Jekyll front matter, even complex multiline ones.